### PR TITLE
Several fixes towards 2.1 milestone:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+CentOS-7-x86_64-Everything-1611.iso
+.vagrant

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,7 +18,7 @@ else
   yum -y install epel-release
 fi
 
-yum -y install python-pip python-jinja2 python-simplejson genisoimage pykickstart createrepo rsync isomd5sum syslinux pigz mock fuseiso libguestfs-tools-c
+yum -y install python-pip python-jinja2 python-simplejson genisoimage pykickstart createrepo rsync isomd5sum syslinux pigz mock fuseiso libguestfs-tools-c initial-setup-gui firstboot
 
 pip install pythonpy
 

--- a/ks/install.ks
+++ b/ks/install.ks
@@ -1,9 +1,9 @@
 # Setup installer
 install
 cdrom
-firstboot --disabled
+firstboot --enable
 eula --agreed
-#reboot --eject
+reboot --eject
 
 # Configure Storage
 ignoredisk --only-use=sda
@@ -83,5 +83,7 @@ ${ROCK_DIR}/bin/generate_defaults.sh
 cp ${ROCK_DIR}/playbooks/files/etc-issue.in /etc/issue.in
 cp ${ROCK_DIR}/playbooks/files/nm-issue-update /etc/NetworkManager/dispatcher.d/50-rocknsm-issue-update
 chmod 755 /etc/NetworkManager/dispatcher.d/50-rocknsm-issue-update
+
+systemctl enable initial-setup-graphical.service
 
 %end

--- a/ks/manual.ks
+++ b/ks/manual.ks
@@ -1,9 +1,13 @@
 # Setup installer
 install
 cdrom
-firstboot --disabled
+firstboot --enable
 eula --agreed
-#reboot --eject
+reboot --eject
+
+# Configure Storage
+clearpart --all --initlabel --drives=sda
+bootloader --location=mbr --boot-drive=sda
 
 # Configure OS
 timezone UTC
@@ -72,11 +76,13 @@ cat << 'EOF' > /etc/rocknsm/config.yml
 rock_online_install: False
 EOF
 
-${ROCK_DIR}/ansible/generate_defaults.sh
+${ROCK_DIR}/bin/generate_defaults.sh
 
 # Install /etc/issue updater
-cp ${ROCK_DIR}/ansible/files/etc-issue.in /etc/issue.in
-cp ${ROCK_DIR}/ansible/files/nm-issue-update /etc/NetworkManager/dispatcher.d/50-rocknsm-issue-update
+cp ${ROCK_DIR}/playbooks/files/etc-issue.in /etc/issue.in
+cp ${ROCK_DIR}/playbooks/files/nm-issue-update /etc/NetworkManager/dispatcher.d/50-rocknsm-issue-update
 chmod 755 /etc/NetworkManager/dispatcher.d/50-rocknsm-issue-update
+
+systemctl enable initial-setup-graphical.service
 
 %end

--- a/ks/packages.list
+++ b/ks/packages.list
@@ -8,6 +8,11 @@ git
 bzip2
 ansible
 
+# Necessary for boot customization
+firstboot
+# initial-setup
+initial-setup-gui
+
 # Needed for better AF_PACKET support for now
 kernel-ml
 

--- a/ks/rock_packages.list
+++ b/ks/rock_packages.list
@@ -27,6 +27,9 @@ kibana
 nginx
 kernel-ml
 kernel-ml-devel
+firstboot
+# initial-setup
+initial-setup-gui
 # Needed for pulledpork
 perl-Crypt-SSLeay
 perl-LWP-Protocol-https

--- a/master-iso.sh
+++ b/master-iso.sh
@@ -134,9 +134,9 @@ EOF
 %end
 EOF
 
-# Generate flattened automated kickstart & add pre-inst hooks
-cond_out ksflatten -c ks/manual.ks -o "${TMP_NEW}/${KICKSTART_MAN}"
-cat <<EOF >> "${TMP_NEW}/${KICKSTART_MAN}"
+  # Generate flattened automated kickstart & add pre-inst hooks
+  cond_out ksflatten -c ks/manual.ks -o "${TMP_NEW}/${KICKSTART_MAN}"
+  cat <<EOF >> "${TMP_NEW}/${KICKSTART_MAN}"
 
 # This seems to get removed w/ ksflatten
 %addon com_redhat_kdump --disable

--- a/offline-snapshot.sh
+++ b/offline-snapshot.sh
@@ -120,6 +120,9 @@ EOF
   curl -Ls -o "rock_$(echo ${ROCK_BRANCH} | tr '/' '-').tar.gz" \
     "https://github.com/rocknsm/rock/archive/${ROCK_BRANCH}.tar.gz"
 
+  echo "Copying EPEL keys..."
+  cp /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7 .
+
   # Because I'm pedantic
   popd >/dev/null
 }


### PR DESCRIPTION
 *  Fix for rock #152 - failing custom install
 *  Fix for rock #146 - forces user creation with `initial-setup`
 *  Prep for rock #142 - Copying EPEL keys so they can be pre-imported
 *  Added `eject` directive back in to avoid "multi-install loops"