### PR TITLE
Remove boot loader timeout

### DIFF
--- a/grub.cfg.j2
+++ b/grub.cfg.j2
@@ -33,7 +33,7 @@ insmod png
 loadfont /EFI/BOOT/fonts/unicode.pf2
 background_image -m stretch /EFI/BOOT/uefi_splash_rock.png
 
-set timeout=60
+set timeout=-1
 ### END /etc/grub.d/00_header ###
 
 search --no-floppy --set=root -l '{{ name }} {{ version }} {{ arch }}'

--- a/isolinux.cfg.j2
+++ b/isolinux.cfg.j2
@@ -1,5 +1,5 @@
 default vesamenu.c32
-timeout 300
+timeout 0
 
 display boot.msg
 


### PR DESCRIPTION
Removes timeout from isolinux and grub configs.

Fixes #17