### PR TITLE
Revert glitch in ISO creation

### DIFF
--- a/master-iso.sh
+++ b/master-iso.sh
@@ -289,7 +289,7 @@ create_iso() {
     -boot-load-size 4 \
     -boot-info-table \
     -eltorito-alt-boot \
-    -eltorito-boot images/efiboot.img \
+    -e images/efiboot.img \
     -no-emul-boot \
     -rock \
     -rational-rock \


### PR DESCRIPTION
The eltorito-boot flag crept back in during merge. Reverting that.