### PR TITLE
Remove plaintext password

### DIFF
--- a/master-iso.sh
+++ b/master-iso.sh
@@ -170,13 +170,6 @@ download_content() {
   # echo "HIDDEN PASSWORD"
   # echo "${GPG_KEY_NAME}"
 
-  # Variable to hold the ansible command
-  cat << EOF | tee /tmp/extra-vars.yml
-skip_gpg: ${SKIP_GPG}
-rock_cache_dir: ${ROCK_CACHE_DIR}
-gpg_passphrase: ${GPG_PASS}
-gpg_key_name: ${GPG_KEY_NAME}
-EOF
   if [[ $YUM_BASE_URL ]]; then
     echo "yum_base_url: ${YUM_BASE_URL}" >> /tmp/extra-vars.yml
   fi


### PR DESCRIPTION
This shows up in plain text in concourse.  It is also redundant due to it being in the ansible command below.

Fixes #35 

I am pretty sure this was producing unexpected results because the sign task was being skipped due to a duplicate variable being set. By removing this portion that is redundant all of the packages were signed.