### PR TITLE
Change concourse iso upload dir

### DIFF
--- a/concourse/upload.sh
+++ b/concourse/upload.sh
@@ -18,4 +18,4 @@ chmod 0600 /root/.ssh/*
 # Upload to local mirror
 rsync -e "ssh -o StrictHostKeyChecking=no -i /root/.ssh/id_ed25519" -rv rocknsm-iso/ $LOCAL_MIRROR_USER@$LOCAL_MIRROR_HOST:/var/www/mirror/public/isos/$LOCAL_MIRROR_REPO/
 # Sync to public mirror
-ssh -i /root/.ssh/id_ed25519 -o StrictHostKeyChecking=no admin@mirror.cyberlab.lan 'rsync -rlvtP -e "ssh -i ~/.ssh/mirror_sync" /var/www/mirror/ mirror_sync@mirror.rocknsm.io:/var/www/mirror/ --delete'
+ssh -i /root/.ssh/id_ed25519 -o StrictHostKeyChecking=no admin@mirror.cyberlab.lan 'rsync -rlvtP -e "ssh -i ~/.ssh/mirror_sync" /var/www/mirror/public/ mirror_sync@mirror.rocknsm.io:/var/www/mirror/ --delete'

--- a/concourse/upload.sh
+++ b/concourse/upload.sh
@@ -16,6 +16,6 @@ echo "$LOCAL_MIRROR_PUBLIC" > "/root/.ssh/id_ed25519.pub"
 # change the permissions on the keys
 chmod 0600 /root/.ssh/*
 # Upload to local mirror
-rsync -e "ssh -o StrictHostKeyChecking=no -i /root/.ssh/id_ed25519" -rv rocknsm-iso/ $LOCAL_MIRROR_USER@$LOCAL_MIRROR_HOST:/var/www/mirror/isos/$LOCAL_MIRROR_REPO/
+rsync -e "ssh -o StrictHostKeyChecking=no -i /root/.ssh/id_ed25519" -rv rocknsm-iso/ $LOCAL_MIRROR_USER@$LOCAL_MIRROR_HOST:/var/www/mirror/public/isos/$LOCAL_MIRROR_REPO/
 # Sync to public mirror
-ssh -i /root/.ssh/id_ed25519 -o StrictHostKeyChecking=no admin@mirror.cyberlab.lan 'rsync -rlvtP -e "ssh -i ~/.ssh/mirror_sync" /var/www/mirror/ mirror_sync@mirror.rocknsm.io:/var/www/mirror/ --delete' 
+ssh -i /root/.ssh/id_ed25519 -o StrictHostKeyChecking=no admin@mirror.cyberlab.lan 'rsync -rlvtP -e "ssh -i ~/.ssh/mirror_sync" /var/www/mirror/ mirror_sync@mirror.rocknsm.io:/var/www/mirror/ --delete'


### PR DESCRIPTION
This pull requested is based off the message you sent me. It will change concourse to upload to the local/private mirror to the directory of `/var/www/mirror/public/isos/` the public mirror available to the general public will be untouched.