### PR TITLE
Match RHEL comps in addition to centos

### DIFF
--- a/master-iso.sh
+++ b/master-iso.sh
@@ -139,7 +139,7 @@ extract_iso() {
   done
 
   # Extract comps file
-  local COMPS=$(isoinfo -i ${SRCISO} -R -f 2>/dev/null | grep 'comps.xml$' | head -1)
+  local COMPS=$(isoinfo -i ${SRCISO} -R -f 2>/dev/null | grep 'comps.*\.xml$' | head -1)
   mkdir -p ${TMP_NEW}/repodata
   isoinfo -i ${SRCISO} -R -x "${COMPS}" 2>/dev/null > ${TMP_NEW}/repodata/comps.xml
 


### PR DESCRIPTION
Rhel names their comps file in the ISO `comps-Server.x86_64.xml` instead of Centos who does `comps.xml`