### PR TITLE
Create variable for mirror ip

### DIFF
--- a/concourse/pipelines/manual/pipeline.yml
+++ b/concourse/pipelines/manual/pipeline.yml
@@ -89,7 +89,7 @@ jobs:
             path: /bin/bash
             args:
               - '-c'
-              - 'rock-createiso-git/concourse/upload.sh "$MIRROR_USER" "$MIRROR_PASS" "$MIRROR_HOST" "$MIRROR_REPO" "$MIRROR_PRIVATE" "$MIRROR_PUBLIC"'
+              - 'rock-createiso-git/concourse/upload.sh "$MIRROR_USER" "$MIRROR_PASS" "$MIRROR_HOST" "$MIRROR_REPO" "$MIRROR_PRIVATE" "$MIRROR_PUBLIC" "$MIRROR_IP"'
           params:
             MIRROR_USER: ((mirror-user))
             MIRROR_PASS: ((mirror-pass))
@@ -97,6 +97,7 @@ jobs:
             MIRROR_REPO: "testing"
             MIRROR_PRIVATE: ((mirror-private-key))
             MIRROR_PUBLIC: ((mirror-public-key))
+            MIRROR_IP: ((mirror-ip))
         on_failure:
           put: RockNSM-Slack
           params:

--- a/concourse/upload.sh
+++ b/concourse/upload.sh
@@ -19,4 +19,4 @@ chmod 0600 /root/.ssh/*
 # Upload to local mirror
 rsync -e "ssh -o StrictHostKeyChecking=no -i /root/.ssh/id_ed25519" -rv rocknsm-iso/ $LOCAL_MIRROR_USER@$LOCAL_MIRROR_IP:/var/www/mirror/public/isos/$LOCAL_MIRROR_REPO/
 # Sync to public mirror
-ssh -i /root/.ssh/id_ed25519 -o StrictHostKeyChecking=no admin@${LOCAL_MIRROR_HOST} 'rsync -rlvtP -e "ssh -i ~/.ssh/mirror_sync" /var/www/mirror/public/ mirror_sync@mirror.rocknsm.io:/var/www/mirror/ --delete'
+ssh -i /root/.ssh/id_ed25519 -o StrictHostKeyChecking=no admin@${LOCAL_MIRROR_IP} 'rsync -rlvtP -e "ssh -i ~/.ssh/mirror_sync" /var/www/mirror/public/ mirror_sync@mirror.rocknsm.io:/var/www/mirror/ --delete'

--- a/concourse/upload.sh
+++ b/concourse/upload.sh
@@ -5,6 +5,7 @@ LOCAL_MIRROR_HOST=$3
 LOCAL_MIRROR_REPO=$4
 LOCAL_MIRROR_PRIVATE=$5
 LOCAL_MIRROR_PUBLIC=$6
+LOCAL_MIRROR_IP=$7
 
 yum install rsync openssh-clients -y
 echo "exporting hidded keys for password less sync"
@@ -16,6 +17,6 @@ echo "$LOCAL_MIRROR_PUBLIC" > "/root/.ssh/id_ed25519.pub"
 # change the permissions on the keys
 chmod 0600 /root/.ssh/*
 # Upload to local mirror
-rsync -e "ssh -o StrictHostKeyChecking=no -i /root/.ssh/id_ed25519" -rv rocknsm-iso/ $LOCAL_MIRROR_USER@$LOCAL_MIRROR_HOST:/var/www/mirror/public/isos/$LOCAL_MIRROR_REPO/
+rsync -e "ssh -o StrictHostKeyChecking=no -i /root/.ssh/id_ed25519" -rv rocknsm-iso/ $LOCAL_MIRROR_USER@$LOCAL_MIRROR_IP:/var/www/mirror/public/isos/$LOCAL_MIRROR_REPO/
 # Sync to public mirror
 ssh -i /root/.ssh/id_ed25519 -o StrictHostKeyChecking=no admin@${LOCAL_MIRROR_HOST} 'rsync -rlvtP -e "ssh -i ~/.ssh/mirror_sync" /var/www/mirror/public/ mirror_sync@mirror.rocknsm.io:/var/www/mirror/ --delete'


### PR DESCRIPTION
MIRROR_HOST contained IP and Port, which breaks rsync command. Created new variable for MIRROR_IP